### PR TITLE
refactor: drop q dependency and use native Promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-androidx",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Cordova/Phonegap plugin to enable AndroidX",
   "author": "Dave Alden",
   "license": "MIT",
@@ -8,8 +8,6 @@
   "bugs": {
     "url": "https://github.com/dpa99c/cordova-plugin-androidx/issues"
   },
-  "dependencies": {
-    "q": "^1.4.1"
-  },
+  "dependencies": {},
   "devDependencies": {}
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-androidx"
-        version="1.0.2">
+        version="2.0.0">
 
     <name>cordova-plugin-androidx</name>
     <description>Cordova/Phonegap plugin to enable AndroidX</description>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?

This PR removes the footprint of this plugin by dropping the, IMHO, redundant `q` dependency and refactors the code to use native Promises instead.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

This drops support for very old Node.js versions ((v4 or lower)) which do not support Promises and/or let/const. This shouldn't be a problem though since those versions aren't even supported by Node.js itself anymore (see https://nodejs.org/en/about/releases/)

## What testing has been done on the changes in the PR?

Created a new Cordova project, installed my fork ensured that the `gradle.properties` has `useAndroidX` and `enableJetifier` set to `true`

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information

I already raised the version in the `package.json` and `plugin.xml` files.