### PR TITLE
Enable plugin for cordova-android < 9

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,7 +10,7 @@
     
     <engines>
       <engine name="cordova" version=">=8.0.0" />
-        <engine name="cordova-android" version=">=8.0.0" />
+        <engine name="cordova-android" version="<9.0.0" />
     </engines>
 
     <platform name="android">


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [ ] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
`cordova-android` starting from version 9 supports setting `AndroidXEnabled`.

https://cordova.apache.org/announcements/2020/06/29/cordova-android-9.0.0.html

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information